### PR TITLE
feat(mobile): update mobile navigation

### DIFF
--- a/src/lib/Header/Header.svelte
+++ b/src/lib/Header/Header.svelte
@@ -32,7 +32,7 @@
 </script>
 
 <header
-	class="md:sticky md:top-0 fixed bottom-0 w-full z-[60] md:flex justify-between flex-row items-center px-5 bg-white select-none dark:bg-darkobject top-shadow shadow"
+	class="md:sticky md:top-0 fixed bottom-0 w-full z-[100] md:flex justify-between flex-row items-center px-5 bg-white select-none dark:bg-darkobject top-shadow shadow"
 	id="header"
 >
 	<a
@@ -117,12 +117,6 @@
 					href="delegations"
 					bind:selectedHref
 				/>
-			{/if}
-
-			{#if $isMobile}
-				<div class="flex flex-shrink-0">
-					<SideHeaderIcon bind:sideHeaderOpen />
-				</div>
 			{/if}
 		</nav>
 

--- a/src/lib/Header/SideHeader.svelte
+++ b/src/lib/Header/SideHeader.svelte
@@ -73,7 +73,7 @@
 
 <div
 	class:hidden={!sideHeaderOpen}
-	class="absolute bottom-full md:bottom-auto md:top-full right-0 z-[110] select-none shadow slide-animation bg-white dark:bg-darkobject dark:text-darkmodeText flex flex-col"
+	class="absolute bottom-auto top-full right-0 z-[110] select-none shadow slide-animation bg-white dark:bg-darkobject dark:text-darkmodeText flex flex-col"
 	id="side-header"
 	role="button"
 	tabindex="0"
@@ -135,12 +135,8 @@
 
 <style>
 	@keyframes slide-animation {
-		from {
-			right: -1000px;
-		}
-		to {
-			right: 0;
-		}
+		from { transform: translateX(100%); }
+		to   { transform: translateX(0); }
 	}
 
 	.slide-animation {

--- a/src/lib/Header/SideHeaderIcon.svelte
+++ b/src/lib/Header/SideHeaderIcon.svelte
@@ -4,12 +4,14 @@
 	import { env } from '$env/dynamic/public';
 	import { onThumbnailError } from '$lib/Generic/GenericFunctions';
 
-	export let sideHeaderOpen = false;
+	export let sideHeaderOpen = false, 
+  Class = "";
 </script>
 
 <button
   id="side-header"
   aria-label="Side Header Toggle"
+  class={Class}
   on:click={() => (sideHeaderOpen = !sideHeaderOpen)}
 >
   <img

--- a/src/lib/Header/TopHeader.svelte
+++ b/src/lib/Header/TopHeader.svelte
@@ -46,7 +46,7 @@
       {$_(pageTitles[selectedHref] || 'Flowback')}
     </h1>
 
-    <div class="relative justify-self-end">
+    <div class="justify-self-end">
       <SideHeaderIcon bind:sideHeaderOpen />
       <SideHeader bind:sideHeaderOpen />
     </div>

--- a/src/lib/Header/TopHeader.svelte
+++ b/src/lib/Header/TopHeader.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+	import { faArrowLeft	} from '@fortawesome/free-solid-svg-icons';
+	import Fa from 'svelte-fa';
+	import { _ } from 'svelte-i18n';
+	import SideHeaderIcon from './SideHeaderIcon.svelte';
+	import { onNavigate } from '$app/navigation';
+	import SideHeader from './SideHeader.svelte';
+	import { onMount } from 'svelte';
+
+	const pageTitles: Record<string, string> = {
+		'home': 'Home',
+		'groups': 'Groups',
+		'kanban': 'Tasks',
+		'schedule': 'Schedule',
+		'ledger': 'Ledger',
+		'delegations': 'Delegation',
+		'user': 'User Profile',
+		'user/settings': 'Settings',
+	};
+
+	let sideHeaderOpen = false, selectedHref = '';
+
+	onMount(() => {
+		selectedHref = window.location.pathname.slice(1);
+	});
+
+	onNavigate(() => {
+		selectedHref = window.location.pathname.slice(1);
+	});
+
+</script>
+
+<div class="relative w-full pb-4 mb-6">
+  <div class="fixed top-0 left-0 right-0 z-[110] shadow-md bg-white dark:bg-gray-900 px-4 py-2 border-b border-gray-200 dark:border-gray-700 grid grid-cols-3 items-center">
+		{#if selectedHref !== 'home'}
+			<button
+				class="text-gray-600 hover:text-primary dark:text-secondary transition-colors"
+				on:click={() => history.back()}
+			>
+				<Fa icon={faArrowLeft} />
+			</button>
+		{:else if selectedHref === 'home'}
+			<div></div>
+		{/if}
+    <h1 class="text-xl text-primary dark:text-secondary font-semibold text-center">
+      {$_(pageTitles[selectedHref] || 'Flowback')}
+    </h1>
+
+    <div class="relative justify-self-end">
+      <SideHeaderIcon bind:sideHeaderOpen />
+      <SideHeader bind:sideHeaderOpen />
+    </div>
+  </div>
+</div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -19,6 +19,8 @@
 	import { ErrorHandlerStore } from '$lib/Generic/ErrorHandlerStore';
 	import { setUserGroupPermissionInfo } from '$lib/Group/functions';
 	import { workgroupStore } from '$lib/Group/Kanban/Kanban';
+	import TopHeader from '$lib/Header/TopHeader.svelte';
+	import { isMobile } from '$lib/utils/isMobile';
 
 	let showUI = false,
 		scrolledY = '',
@@ -200,6 +202,9 @@
 
 <main class="min-h-[100vh] pb-[15vh] md:pb-0">
 	{#if showUI}
+		{#if $isMobile}
+			<TopHeader />
+		{/if}
 		<!-- <Chat /> -->
 		<Header />
 	{/if}

--- a/src/routes/user/settings/+page.svelte
+++ b/src/routes/user/settings/+page.svelte
@@ -169,7 +169,7 @@
 			{$isMobile ? "h-full" : "w-[300px] h-[800px] rounded border"}"
 			class:hidden={$isMobile && selectedPage}
 		>
-			<div class={$isMobile ? "grid grid-cols-3 w-full pb-4 border-b border-gray-200 dark:border-gray-70" : "flex items-center mb-4 gap-4"}>
+			<div class={$isMobile ? "hidden" : "flex items-center mb-4 gap-4"}>
 				<button
 					class="text-gray-600 hover:text-primary dark:text-secondary transition-colors"
 					on:click={() => goto('/home')}
@@ -203,21 +203,6 @@
 				class="bg-white dark:bg-darkobject dark:text-darkmodeText p-6 shadow
 				{$isMobile ? "h-full" : "w-[450px] rounded border"}"
 			>
-			 	{#if $isMobile}
-					<div class="grid grid-cols-3 w-full pb-4 mb-6 border-b border-gray-200 dark:border-gray-70">
-						<button
-							class="text-gray-600 hover:text-primary dark:text-secondary transition-colors"
-							on:click={() => {
-									selectedPage = null;
-							}}
-						>
-							<Fa icon={faArrowLeft} />
-						</button>
-						<h1 class="text-xl text-left text-primary dark:text-secondary font-semibold text-center">
-							{$_(sidebarItems.find(i => i.page === selectedPage)?.text || 'Settings')}
-						</h1>
-					</div>
-				{/if}
 				<ul class="flex flex-col h-full">
 					{#if selectedPage === 'profile'}
 						<li

--- a/src/routes/user/settings/+page.svelte
+++ b/src/routes/user/settings/+page.svelte
@@ -159,6 +159,10 @@
 		getUserConfig();
 		getServerConfig();
 		getReportList();
+
+		window.addEventListener('popstate', () => {
+			selectedPage = null;
+		});
 	});
 </script>
 
@@ -184,7 +188,7 @@
 				<div class="mt-4">
 					{#each sidebarItems as item}
 						<button
-							on:click={() => (selectedPage = item.page)}
+							on:click={() => { selectedPage = item.page; history.pushState({}, ''); }}
 							class={optionsDesign}
 							class:bg-gray-100={selectedPage === item.page}
 							class:dark:bg-gray-800={selectedPage === item.page}


### PR DESCRIPTION
Add TopHeader to mobile version, containing a back button (to the left) and profile icon (to the right).

<img width="200" alt="flowback_mobile_nav_top_header" src="https://github.com/user-attachments/assets/006febcd-792b-474f-bd1c-6182d68a7bdf" />
<img width="200" alt="flowback_mobile_nav_top_header_settings" src="https://github.com/user-attachments/assets/61a4a3bc-5455-42a4-a86a-64db0d913dd3" />